### PR TITLE
Friends Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ P2 is a web3 version of a peer to peer payment platform (think venmo, zelle, etc
 P2 is more user friendly than just using the base layer of ETH to move value, because it relies on usernames rather than unreadable wallet addresses. 
 
 ## In the works (in no particular order)
-1. Add ERC20 tokens *done*
+1. Add ERC20 tokens **done**
 2. Add ability to add users as 'friends' who can request payments (similar to venmo) **done**
 3. Remove USD conversions (to make #1 more smooth)
 4. Test profusely

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ P2 is more user friendly than just using the base layer of ETH to move value, be
 ## In the works (in no particular order)
 1. Add ERC20 tokens **done**
 2. Add ability to add users as 'friends' who can request payments (similar to venmo) **done**
-3. Remove USD conversions (to make #1 more smooth)
+3. Remove USD conversions (to make #1 more smooth) **done**
 4. Test profusely
 5. Simple frontend to visualize functionality

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ P2 is more user friendly than just using the base layer of ETH to move value, be
 
 ## In the works (in no particular order)
 1. Add ERC20 tokens *done*
-2. Add ability to add users as 'friends' who can request payments (similar to venmo)
+2. Add ability to add users as 'friends' who can request payments (similar to venmo) **done**
 3. Remove USD conversions (to make #1 more smooth)
 4. Test profusely
 5. Simple frontend to visualize functionality

--- a/contracts/P2.sol
+++ b/contracts/P2.sol
@@ -7,9 +7,10 @@ import "../node_modules/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Int
 import "../node_modules/openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 /*
-*   TO-DO: Add ability to add friends
+*   TO-DO: 
+*   Add ability to add friends
+*   Friends will be able to request money from each other
 */
-
 contract P2 is Ownable, ReentrancyGuard, Percentages{
     constructor() {
         addToken("ETH", 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
@@ -28,10 +29,30 @@ contract P2 is Ownable, ReentrancyGuard, Percentages{
     struct Account {
         string username;
         bool hasAccount;
-        mapping(string => uint256) tokenBalances;
     }
     mapping(address => Account) public accounts;
+    mapping(address => mapping(string => uint256)) tokenBalances;
 
+    // Experimental ->
+    enum ReqType {
+        SENT,
+        RECEIVED
+    }
+    struct Request {
+        uint256 id;
+        address requestSender;
+        address requestRecipient;
+        string ticker;
+        uint256 amount;
+        string memo;
+        bool fulfilled;
+    }
+    uint256 public nextReqId;
+    Request[] public reqs;
+    mapping(address => mapping(uint256 => uint256[])) public reqMapping; // address -> ReqType -> reqId
+
+    // <-
+    mapping(address => mapping(address => bool)) friends;
     mapping(string => address) public usernameToAddress;
 
     modifier tokenExists(string memory ticker) {
@@ -64,32 +85,32 @@ contract P2 is Ownable, ReentrancyGuard, Percentages{
     function depositETH() external payable nonReentrant {
         require(accounts[_msgSender()].hasAccount, "Sender has not created an account");
 
-        uint256 oldBalance = accounts[_msgSender()].tokenBalances["ETH"];
+        uint256 oldBalance = tokenBalances[_msgSender()]["ETH"];
 
-        accounts[_msgSender()].tokenBalances["ETH"] += msg.value;
+        tokenBalances[_msgSender()]["ETH"] += msg.value;
 
-        emit funded(accounts[_msgSender()].username, _msgSender(), msg.value, oldBalance, accounts[_msgSender()].tokenBalances["ETH"]);
+        emit funded(accounts[_msgSender()].username, _msgSender(), msg.value, oldBalance, tokenBalances[_msgSender()]["ETH"]);
     }
 
     function depositERC20(string memory ticker, uint256 amount) external tokenExists(ticker){
         IERC20(tokenMapping[ticker].tokenAddress).transferFrom(msg.sender, address(this), amount);
 
-        accounts[_msgSender()].tokenBalances[ticker] += amount;
+        tokenBalances[_msgSender()][ticker] += amount;
     }
 
     function sendERC20(string calldata _toUsername, string calldata ticker, uint256 amount, string calldata memo) external tokenExists(ticker) {
-        require(accounts[_msgSender()].tokenBalances[ticker] >= amount, "Insufficient balance");
-        accounts[_msgSender()].tokenBalances[ticker] -= amount;
+        require(tokenBalances[_msgSender()][ticker] >= amount, "Insufficient balance");
+        tokenBalances[_msgSender()][ticker] -= amount;
 
-        accounts[usernameToAddress[_toUsername]].tokenBalances[ticker] += amount;
+        tokenBalances[usernameToAddress[_toUsername]][ticker] += amount;
 
         emit sent(_toUsername, accounts[_msgSender()].username, ticker, amount, memo);
     }
 
     function sendETH(string calldata _toUsername, uint256 amount, string calldata memo) external isInitialized(_toUsername) nonReentrant {
-        require(accounts[_msgSender()].tokenBalances["ETH"] >= amount, "Insufficient balance");
-        accounts[_msgSender()].tokenBalances["ETH"] -= amount;
-        accounts[usernameToAddress[_toUsername]].tokenBalances["ETH"] += amount;
+        require(tokenBalances[_msgSender()]["ETH"] >= amount, "Insufficient balance");
+        tokenBalances[_msgSender()]["ETH"] -= amount;
+        tokenBalances[usernameToAddress[_toUsername]]["ETH"] += amount;
 
         emit sent(_toUsername, accounts[_msgSender()].username, "ETH", amount, memo);
     }
@@ -97,13 +118,13 @@ contract P2 is Ownable, ReentrancyGuard, Percentages{
     function withdrawETH(uint256 _amount, bool withdrawAll) external nonReentrant {
         uint256 amount = _amount;
         if(withdrawAll) {
-            amount = accounts[_msgSender()].tokenBalances["ETH"];
+            amount = tokenBalances[_msgSender()]["ETH"];
         }
 
-        require(accounts[_msgSender()].tokenBalances["ETH"] >= amount, "Insufficient balance");
+        require(tokenBalances[_msgSender()]["ETH"] >= amount, "Insufficient balance");
 
-        uint256 oldBalance = accounts[_msgSender()].tokenBalances["ETH"];
-        accounts[_msgSender()].tokenBalances["ETH"] -= amount;
+        uint256 oldBalance = tokenBalances[_msgSender()]["ETH"];
+        tokenBalances[_msgSender()]["ETH"] -= amount;
 
         uint256 fee = percentageOf(amount, 1) / 4; // 0.25% 
     
@@ -113,14 +134,14 @@ contract P2 is Ownable, ReentrancyGuard, Percentages{
         (bool success2,) = payable(owner()).call{value: fee}("");
         require(success2, 'Transfer fail');
 
-        emit withdrawal(accounts[_msgSender()].username, _msgSender(), amount, oldBalance, accounts[_msgSender()].tokenBalances["ETH"], fee);
+        emit withdrawal(accounts[_msgSender()].username, _msgSender(), amount, oldBalance, tokenBalances[_msgSender()]["ETH"], fee);
     }
 
     function withdrawERC20(uint256 amount, string memory ticker) external nonReentrant tokenExists(ticker) {
-        require(accounts[_msgSender()].tokenBalances[ticker] >= amount, "Insufficient balance");
+        require(tokenBalances[_msgSender()][ticker] >= amount, "Insufficient balance");
 
-        uint256 oldBalance = accounts[_msgSender()].tokenBalances[ticker];
-        accounts[_msgSender()].tokenBalances[ticker] -= amount;
+        uint256 oldBalance = tokenBalances[_msgSender()][ticker];
+        tokenBalances[_msgSender()][ticker] -= amount;
 
         uint256 fee = percentageOf(amount, 1) / 4; // 0.25% 
     
@@ -128,18 +149,55 @@ contract P2 is Ownable, ReentrancyGuard, Percentages{
         IERC20(tokenMapping[ticker].tokenAddress).transferFrom(address(this), owner(), fee);
         //accounts[owner()].tokenBalances[ticker] += fee;
 
-        emit withdrawal(accounts[_msgSender()].username, _msgSender(), amount, oldBalance, accounts[_msgSender()].tokenBalances[ticker], fee);
+        emit withdrawal(accounts[_msgSender()].username, _msgSender(), amount, oldBalance, tokenBalances[_msgSender()][ticker], fee);
     }
 
     function tokenBalance(string memory ticker, string memory _username) public view returns(uint256) {
-        return accounts[usernameToAddress[_username]].tokenBalances[ticker];
+        return tokenBalances[usernameToAddress[_username]][ticker];
     }
 
     function addToken(string memory ticker, address tokenAddress) public onlyOwner {
         tokenMapping[ticker] = Token(ticker, tokenAddress);
     }
 
-    // function ownerWithdraw(string memory ticker) external onlyOwner {
+    // Experimental ->
+    function addFriend(string calldata username) external isInitialized(username) {
+        friends[_msgSender()][usernameToAddress[username]] = true;
+    }
 
-    // }
+    function requestMoney(string calldata username, string calldata ticker, uint256 amount, string calldata memo) external tokenExists(ticker) {
+        require(friends[usernameToAddress[username]][_msgSender()], "Can only request from friends");
+
+        reqMapping[_msgSender()][uint(ReqType.SENT)].push(nextReqId);
+        reqMapping[usernameToAddress[username]][uint(ReqType.RECEIVED)].push(nextReqId);
+
+        reqs.push(Request(nextReqId, _msgSender(), usernameToAddress[username], ticker, amount, memo, false));
+
+        nextReqId++;
+    }
+
+    function fulfillRequest(uint256 reqId) external {
+        require(!reqs[reqId].fulfilled, "Already fulfilled");
+        require(tokenBalances[_msgSender()][reqs[reqId].ticker] >= reqs[reqId].amount, "Insufficient balance");
+        require(reqs[reqId].requestRecipient == _msgSender(), "Sender is not request recipient");
+        
+        reqs[reqId].fulfilled = true;
+
+        tokenBalances[reqs[reqId].requestSender][reqs[reqId].ticker] += reqs[reqId].amount;
+        tokenBalances[_msgSender()][reqs[reqId].ticker] -= reqs[reqId].amount;
+    }
+
+    function getRequests(ReqType _type) external view returns(uint256[] memory) {
+        return reqMapping[_msgSender()][uint256(_type)];
+    }
+    /*    
+        uint256 id;
+        address requestSender;
+        address requestRecipient;
+        string ticker;
+        uint256 amount;
+        string memo;
+        bool fulfilled;
+    */
+    // <-
 }

--- a/contracts/P2.sol
+++ b/contracts/P2.sol
@@ -6,10 +6,8 @@ import "./Percentages.sol";
 import "../node_modules/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "../node_modules/openzeppelin-contracts/token/ERC20/IERC20.sol";
 
-// 0x0A77230d17318075983913bC2145DB16C7366156 -- AVAX
-
 /*
-*   TO-DO: Add support for ERC20
+*   TO-DO: Add ability to add friends
 */
 
 contract P2 is Ownable, ReentrancyGuard, Percentages{


### PR DESCRIPTION
Changes allow users to add other users as 'friends'.

- Adding friends is one-way, to maintain security
- Meaning account A must add account B in order for account B to request funds from account A
- When funds are requested, it creates a struct with the data about the request (currency, amount, memo, etc)
- The recipient of a request can fulfill the request using the request ID